### PR TITLE
fix: bring back `update` method calling through the `HeadManager` Proxy

### DIFF
--- a/client.cjs
+++ b/client.cjs
@@ -222,6 +222,9 @@ class Head {
   constructor (initial, document) {
     return new Proxy(new HeadManager(initial, document), {
       get (head, elem) {
+        if (elem === 'update') {
+          return initialHead => head.update(initialHead)
+        }
         if (elem === 'reset') {
           return () => head.reset()
         }

--- a/client.mjs
+++ b/client.mjs
@@ -222,6 +222,9 @@ class Head {
   constructor (initial, document) {
     return new Proxy(new HeadManager(initial, document), {
       get (head, elem) {
+        if (elem === 'update') {
+          return initialHead => head.update(initialHead)
+        }
         if (elem === 'reset') {
           return () => head.reset()
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unihead",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unihead",
-      "version": "0.0.4",
+      "version": "0.0.7",
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.0",
         "eslint": "^7.28.0",

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -82,6 +82,26 @@ t.test('can mutate meta tags', (t) => {
   }
 })
 
+t.test('can mutate meta tags with update', (t) => {
+  t.plan(4)
+  const window = new Window()
+  const document = window.document
+  document.head.innerHTML = `
+    <meta property="twitter:title" content="Page Title">
+    <meta property="twitter:url" content="https://example.com">
+  `
+  const head = getHead(null, document)
+  const changed = [
+    { property: 'twitter:title', content: 'Changed Title'},
+    { property: 'twitter:url', content: 'https://example.com/2' },
+  ]
+  head.update({ meta: changed })
+  for (const [i, metaTag] of Object.entries([...document.querySelectorAll('head > meta')])) {
+    t.equal(changed[i].property, metaTag.attributes.property.value)
+    t.equal(changed[i].content, metaTag.attributes.content.value)
+  }
+})
+
 
 t.test('can reset to initial state', (t) => {
   t.plan(10)


### PR DESCRIPTION
Looking to fix #2 

I'm not sure if this is the correct path; it just brings back the `update` method from 0.0.6.